### PR TITLE
feat: add nginx fastcgi configuration for luci-theme-spectra

### DIFF
--- a/luci-theme-spectra/root/etc/nginx/conf.d/spectra.locations
+++ b/luci-theme-spectra/root/etc/nginx/conf.d/spectra.locations
@@ -1,0 +1,15 @@
+location /spectra/ {
+	location ~ \.php$ {
+		fastcgi_param HTTP_PROXY "";
+		fastcgi_connect_timeout 300s;
+		fastcgi_read_timeout 300s;
+		fastcgi_send_timeout 300s;
+		fastcgi_buffer_size 32k;
+		fastcgi_buffers 4 32k;
+		fastcgi_busy_buffers_size 32k;
+		fastcgi_temp_file_write_size 32k;
+		include fastcgi_params;
+		fastcgi_pass 127.0.0.1:1026;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+	}
+}


### PR DESCRIPTION
## Problem

`luci-theme-spectra` includes 27 PHP files under `/www/spectra/` but provides no nginx `.locations` configuration. When nginx is the web server (instead of uhttpd), these PHP files are served as static files (`application/octet-stream`), causing the browser to download them instead of executing them.

This is because uhttpd handles all `.php` files automatically via its `interpreter` config, but nginx requires explicit `fastcgi_pass` location blocks.

## Fix

Add `luci-theme-spectra/root/etc/nginx/conf.d/spectra.locations` with a nested location structure:
- Outer `location /spectra/` (prefix match) — serves static files (CSS/JS/images) directly
- Inner `location ~ \.php$` (regex match) — routes PHP files to `php8-fcgi` on port 1026

## Testing

Verified on OpenWrt device with nginx:
- `/spectra/index.php` → 200 `text/html; charset=UTF-8` ✅
- `/spectra/cfg.php` → 200 `text/html; charset=UTF-8` ✅

No impact on uhttpd environments (`.locations` files are only loaded by nginx via `include conf.d/*.locations`).