### PR TITLE
feat: add nginx fastcgi configuration for luci-app-nekobox

### DIFF
--- a/luci-app-nekobox/root/etc/nginx/conf.d/nekobox.locations
+++ b/luci-app-nekobox/root/etc/nginx/conf.d/nekobox.locations
@@ -1,0 +1,17 @@
+location /nekobox/ {
+	index index.php;
+
+	location ~ \.php$ {
+		fastcgi_param HTTP_PROXY "";
+		fastcgi_connect_timeout 300s;
+		fastcgi_read_timeout 300s;
+		fastcgi_send_timeout 300s;
+		fastcgi_buffer_size 32k;
+		fastcgi_buffers 4 32k;
+		fastcgi_busy_buffers_size 32k;
+		fastcgi_temp_file_write_size 32k;
+		include fastcgi_params;
+		fastcgi_pass 127.0.0.1:1026;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+	}
+}


### PR DESCRIPTION
## Problem

`luci-app-nekobox` includes 36 PHP files under `/www/nekobox/` but provides no nginx `.locations` configuration. When nginx is the web server (instead of uhttpd), these PHP files are served as static files (`application/octet-stream`), causing the browser to download them instead of executing them.

## Fix

Add `luci-app-nekobox/root/etc/nginx/conf.d/nekobox.locations` with a nested location structure:
- Outer `location /nekobox/` (prefix match) — serves static files (CSS/JS/images) directly
- Inner `location ~ \.php$` (regex match) — routes PHP files to `php8-fcgi` on port 1026

## Testing

Verified on OpenWrt device with nginx:
- `/nekobox/index.php` → 200 `text/html; charset=UTF-8` ✅
- `/nekobox/cfg.php` → 200 `text/html; charset=UTF-8` ✅
- `/nekobox/mihomo.php` → 200 `text/html; charset=UTF-8` ✅
- `/nekobox/panel.php` → 200 `text/html; charset=UTF-8` ✅

No impact on uhttpd environments (`.locations` files are only loaded by nginx via `include conf.d/*.locations`).